### PR TITLE
Bugfix/2022 events categories sorting

### DIFF
--- a/frontend/pages/events.js
+++ b/frontend/pages/events.js
@@ -147,7 +147,7 @@ const Events = () => {
     const filteredTerm = pastContent[term].filter(
       (picture) =>
         selectedCategory === "All" ||
-        picture.category.split(",").includes(selectedCategory)
+        (picture.category != null && picture.category.split(",").includes(selectedCategory))
     );
 
     return filteredTerm;


### PR DESCRIPTION
Fixed the bug - the bug was due to the category of some events being empty/null and hence split could not be used on it.